### PR TITLE
Always quote attributes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Change `quote_attr_values` from `legacy` to `always` to unbreak the Pelican's intrasite link regex.

--- a/pelican/plugins/simple_footnotes/simple_footnotes.py
+++ b/pelican/plugins/simple_footnotes/simple_footnotes.py
@@ -86,7 +86,7 @@ def parse_for_footnotes(article_or_page_generator):
                     e.parentNode.removeChild(e)
                 dom.getElementsByTagName(u"body")[0].appendChild(ol)
                 s = html5lib.serializer.HTMLSerializer(
-                    omit_optional_tags=False, quote_attr_values="legacy"
+                    omit_optional_tags=False, quote_attr_values="always"
                 )
                 output_generator = s.serialize(
                     html5lib.treewalkers.getTreeWalker(u"dom")(

--- a/pelican/plugins/simple_footnotes/test_simple_footnotes.py
+++ b/pelican/plugins/simple_footnotes/test_simple_footnotes.py
@@ -25,9 +25,9 @@ class TestFootnotes(unittest.TestCase):
         self._expect(
             "words[ref]footnote[/ref]end",
             (
-                "words<sup id=sf-article-1-back><a href=#sf-article-1 class=simple-footnote title=footnote>1</a></sup>end"
-                "<ol class=simple-footnotes>"
-                u"<li id=sf-article-1>footnote <a href=#sf-article-1-back class=simple-footnote-back>\u21a9</a></li>"
+                'words<sup id="sf-article-1-back"><a href="#sf-article-1" class="simple-footnote" title="footnote">1</a></sup>end'
+                '<ol class="simple-footnotes">'
+                u'<li id="sf-article-1">footnote <a href="#sf-article-1-back" class="simple-footnote-back">\u21a9</a></li>'
                 "</ol>"
             ),
         )


### PR DESCRIPTION
The regex in `Content._get_intrasite_link_regex()` expects attributes to be quoted. When `quote_attr_values` has the value `legacy` when serialising the parsed HTML with html5lib, it ends up omitting the quotes expected, which breaks intrasite links. Changing this to `always` ensures that the quotes remain present if simple_bookmarks processes the page.

I expect this will also fix getpelican/pelican-plugins#1240.