### PR TITLE
Add Unicode variation selector to arrow character

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This will appear as, roughly:
 
 Here’s my written text<sup>1</sup>
 
- 1. and here is a footnote ↩
+ 1. and here is a footnote ↩&#xFE0E;
 
 This should work with any content format (reST, Markdown, et cetera), because
 it looks for `[ref]` and `[/ref]` once the conversion to HTML has happened.

--- a/pelican/plugins/simple_footnotes/simple_footnotes.py
+++ b/pelican/plugins/simple_footnotes/simple_footnotes.py
@@ -76,7 +76,7 @@ def parse_for_footnotes(article_or_page_generator):
                     backlink = dom.createElement("a")
                     backlink.setAttribute("href", "#%s" % fnbackid)
                     backlink.setAttribute("class", "simple-footnote-back")
-                    backlink.appendChild(dom.createTextNode("\u21a9"))
+                    backlink.appendChild(dom.createTextNode("\u21a9\ufe0e"))
                     li.appendChild(dom.createTextNode(" "))
                     li.appendChild(backlink)
                     ol.appendChild(li)


### PR DESCRIPTION
Unicode variation selector U+FE0E forces the arrow character U+21A9 to render as text rather than its corresponding Emoji on iOS.